### PR TITLE
Fix for #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.build
 /Packages
 /*.xcodeproj
+
+.swiftpm/xcode/xcuserdata/
+
+.swiftpm/xcode/package.xcworkspace/xcuserdata/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tests/LibPNGTests/LibPNGTests.swift
+++ b/Tests/LibPNGTests/LibPNGTests.swift
@@ -89,11 +89,21 @@ final class LibPNGTests: XCTestCase {
         }
         XCTAssert(image.data != nil)
     }
+    
+    
+    func testInitSolidColorImage() {
+        XCTAssertNoThrow(try Image(width: 800, height: 600, colorType: .rgb, pixelValues: [Double](repeating: 0, count: 800 * 600 * 3)))
+        XCTAssertNoThrow(try Image(width: 800, height: 600, colorType: .rgb, pixelValues: [Double](repeating: 0.5, count: 800 * 600 * 3)))
+        XCTAssertNoThrow(try Image(width: 800, height: 600, colorType: .rgb, pixelValues: [Double](repeating: 1, count: 800 * 600 * 3)))
+    }
+    
+    
     static var allTests = [
         ("testGetImageData", testGetImageData),
         ("testWriteDoubleColoredImage", testWriteDoubleColoredImage),
         ("testWriteDoubleImage", testWriteDoubleImage),
         ("testWriteGreyscaleImage", testWriteGreyscaleImage),
+        ("testInitSolidColorImage", testInitSolidColorImage),
     ]
 }
 


### PR DESCRIPTION
Accounted for `minPixelValue` being equal to `maxPixelValue`.

If they're all the same, then fill it with that one color. Else, use the old algorithm with `0` as a backup in case of `NaN`.

This fixes #1 .

Additional changes included:

* Updated `.gitignore` to be more appropriate for SwiftPM
* Added Xcode workspace data file